### PR TITLE
feat: Implement getAllBlogsByBlogStatus API for viewing blog list by status

### DIFF
--- a/BackEnd/src/main/java/com/dac/BackEnd/controller/Admin/BlogsAdminController.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/controller/Admin/BlogsAdminController.java
@@ -4,16 +4,22 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
 import java.util.Arrays;
+import java.util.ArrayList;
 
+import com.dac.BackEnd.entity.BlogEntity.BlogStatus;
 import com.dac.BackEnd.exception.MessageException;
+import com.dac.BackEnd.model.Blog;
 import com.dac.BackEnd.model.response.ResponseBody;
 import com.dac.BackEnd.model.response.ResponsePage;
 import com.dac.BackEnd.service.BlogService;
+import com.dac.BackEnd.validation.BlogStatusValidation;
 
 
 @RestController
@@ -32,6 +38,27 @@ public class BlogsAdminController {
             body.setData(blogService.getAllBlogs(page));
             body.setPageInfo(responsePage);
             body.setMessage(Arrays.asList("Success"));
+            return ResponseEntity.ok().body(body);
+        } catch (Exception e) {
+            ResponseBody body = new ResponseBody();
+            body.setCode(404);
+            body.setMessage(Arrays.asList(new MessageException(e.getMessage(), 404)));
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
+        }
+    }
+
+    @GetMapping("filter")
+    public ResponseEntity<ResponseBody> getAllBlogsByBlogStatus(@RequestParam(required = false, defaultValue = "1") int page, @RequestParam(required = false, defaultValue = "WAITING") String status) {
+        try {
+            BlogStatus blogStatus = BlogStatusValidation.checkValidStatus(status);
+            ResponsePage responsePage = blogService.getPageInfoByStatus(page, blogStatus);
+            ResponseBody body = new ResponseBody();
+
+            body.setCode(200);
+            body.setData(blogService.getAllBlogsByStatus(page, blogStatus));
+            body.setMessage(Arrays.asList("Success"));
+            body.setPageInfo(responsePage);
+
             return ResponseEntity.ok().body(body);
         } catch (Exception e) {
             ResponseBody body = new ResponseBody();

--- a/BackEnd/src/main/java/com/dac/BackEnd/repository/BlogRepository.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/repository/BlogRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.dac.BackEnd.entity.BlogEntity.BlogEntity;
+import com.dac.BackEnd.entity.BlogEntity.BlogStatus;
 
 import java.util.List;
 
@@ -17,4 +18,10 @@ public interface BlogRepository extends JpaRepository<BlogEntity, Long>{
 
     @Query(value = "SELECT * FROM blogs ORDER BY insert_date_time DESC LIMIT 10 OFFSET :pageNumber", nativeQuery = true)
     List<BlogEntity> findAllBlogsPerPage(@Param("pageNumber") int pageNumber);
+
+    @Query(value = "SELECT COUNT(*) FROM blogs WHERE status = :status", nativeQuery = true)
+    int countAllBlogsByStatus(@Param("status") BlogStatus status);
+
+    @Query(value = "SELECT * FROM blogs WHERE status = :status ORDER BY insert_date_time DESC LIMIT 10 OFFSET :pageNumber", nativeQuery = true)
+    List<BlogEntity> findAllByStatus(@Param("status") BlogStatus status, @Param("pageNumber") int pageNumber);
 }

--- a/BackEnd/src/main/java/com/dac/BackEnd/service/BlogService.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/service/BlogService.java
@@ -2,6 +2,7 @@ package com.dac.BackEnd.service;
 
 import java.util.List;
 
+import com.dac.BackEnd.entity.BlogEntity.BlogStatus;
 import com.dac.BackEnd.model.Blog;
 import com.dac.BackEnd.model.response.ResponsePage;
 
@@ -11,6 +12,8 @@ public interface BlogService {
 
     List<Blog> getAllBlogs(int page);
 
-    
+    ResponsePage getPageInfoByStatus(int page, BlogStatus status);
+
+    List<Blog> getAllBlogsByStatus(int page, BlogStatus status);
     
 }

--- a/BackEnd/src/main/java/com/dac/BackEnd/service/impl/BlogServiceImpl.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/service/impl/BlogServiceImpl.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 
 import com.dac.BackEnd.convertor.BlogConvertor;
 import com.dac.BackEnd.entity.BlogEntity.BlogEntity;
+import com.dac.BackEnd.entity.BlogEntity.BlogStatus;
 import com.dac.BackEnd.model.Blog;
 import com.dac.BackEnd.model.response.ResponsePage;
 import com.dac.BackEnd.repository.BlogRepository;
@@ -28,6 +29,7 @@ public class BlogServiceImpl implements BlogService{
         if (page < 1 || page > totalPages) {
             throw new IllegalArgumentException("Invalid page number");
         }
+
         ResponsePage responsePage = new ResponsePage();
         responsePage.setPage(page);
         responsePage.setPer_page(10);
@@ -39,6 +41,29 @@ public class BlogServiceImpl implements BlogService{
     @Override
     public List<Blog> getAllBlogs(int page) {
         return blogRepository.findAllBlogsPerPage((page - 1)  * 10).stream().map(BlogConvertor::toModel).toList();
+    }
+
+    @Override
+    public ResponsePage getPageInfoByStatus(int page, BlogStatus status) {
+        int totalBlogs = blogRepository.countAllBlogsByStatus(status);
+        int totalPages = (int) Math.ceil((double) totalBlogs / 10);
+
+        if (page < 1 || page > totalPages) {
+            throw new IllegalArgumentException("Invalid page number");
+        }
+        ResponsePage responsePage = new ResponsePage();
+        responsePage.setPage(page);
+        responsePage.setPer_page(10);
+        responsePage.setTotal(totalBlogs);
+        responsePage.setTotal_pages(totalPages);
+
+        return responsePage;
+    }
+
+    @Override
+    public List<Blog> getAllBlogsByStatus(int page, BlogStatus status) {
+        return blogRepository.findAllByStatus(status, page).stream().map(BlogConvertor::toModel).toList();
+       
     }
 
 }

--- a/BackEnd/src/main/java/com/dac/BackEnd/validation/BlogStatusValidation.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/validation/BlogStatusValidation.java
@@ -1,0 +1,17 @@
+package com.dac.BackEnd.validation;
+
+import com.dac.BackEnd.entity.BlogEntity.BlogStatus;
+
+public class BlogStatusValidation {
+
+    // Phương thức kiểm tra status có hợp lệ không
+    public static BlogStatus checkValidStatus(String status) {
+        for (BlogStatus validStatus : BlogStatus.values()) {
+            if (validStatus.toString().equals(status)) {
+                return validStatus;
+            }
+        }
+        // Ném ra ngoại lệ IllegalArgumentException nếu status không hợp lệ
+        throw new IllegalArgumentException("Invalid status: " + status);
+    }
+}


### PR DESCRIPTION
- Created getAllBlogsByBlogStatus API endpoint in the Admin section to retrieve blog list based on status.
- Added validation to check the validity of the status parameter.
- Handled cases where the status is invalid or the page number is not found.
- Returned appropriate response codes and messages for different scenarios.
- Integrated with existing service methods to fetch and paginate blog data.