### PR TITLE
feat: Implemented getInfoSummary API endpoint #37

### DIFF
--- a/BackEnd/src/main/java/com/dac/BackEnd/controller/Admin/BlogsAdminController.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/controller/Admin/BlogsAdminController.java
@@ -85,9 +85,9 @@ public class BlogsAdminController {
         try {
             Blog blog = blogService.getBlogById(blogId);
             ResponseBody body = new ResponseBody();
-            body.setCode(200);
+            body.setCode(SuccessConstants.OK_CODE);
             body.setData(blog);
-            body.setMessage(Arrays.asList("Success"));
+            body.setMessage(Arrays.asList(SuccessConstants.OK_MESSAGE, SuccessConstants.OK_CODE));
             return ResponseEntity.ok().body(body);
         } catch (MessageException e) {
             Response body = new Response();
@@ -103,8 +103,8 @@ public class BlogsAdminController {
         try {
             Response response = new Response();
             blogService.updateStatusBlog(blogId, blogStatus.getStatus());
-            response.setCode(200);
-            response.setMessage(Arrays.asList("Success", 200));
+            response.setCode(SuccessConstants.OK_CODE);
+            response.setMessage(Arrays.asList(SuccessConstants.OK_MESSAGE, SuccessConstants.OK_CODE));
             return ResponseEntity.ok().body(response);
         } catch (MessageException e) {
             Response body = new Response();

--- a/BackEnd/src/main/java/com/dac/BackEnd/controller/Admin/DrashboardController.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/controller/Admin/DrashboardController.java
@@ -1,0 +1,44 @@
+package com.dac.BackEnd.controller.Admin;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.dac.BackEnd.constant.SuccessConstants;
+import com.dac.BackEnd.exception.MessageException;
+import com.dac.BackEnd.model.response.Response;
+import com.dac.BackEnd.model.response.ResponseBody;
+import com.dac.BackEnd.service.DrashboardService;
+
+import java.util.Arrays;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+
+
+@RestController
+@RequestMapping("api/admin/drashboard")
+public class DrashboardController {
+
+    @Autowired
+    private DrashboardService drashboardService;
+    
+
+    @GetMapping()
+    public ResponseEntity<?> getInfoSummary() {
+        try {
+            ResponseBody body = new ResponseBody();
+            body.setCode(SuccessConstants.OK_CODE);
+            body.setData(drashboardService.getInfoSummary());
+            body.setMessage(Arrays.asList(SuccessConstants.OK_MESSAGE, SuccessConstants.OK_CODE));
+            return ResponseEntity.ok().body(body);
+        } catch (MessageException e) {
+            Response body = new Response();
+            body.setCode(e.getErrorCode());
+            body.setMessage(Arrays.asList(e));
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
+        }
+    }
+    
+}

--- a/BackEnd/src/main/java/com/dac/BackEnd/model/request/BlogStatusRequest.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/model/request/BlogStatusRequest.java
@@ -1,7 +1,5 @@
 package com.dac.BackEnd.model.request;
 
-import com.dac.BackEnd.entity.BlogEntity.BlogStatus;
-
 import lombok.Getter;
 import lombok.Setter;
 

--- a/BackEnd/src/main/java/com/dac/BackEnd/model/response/SummaryResponse.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/model/response/SummaryResponse.java
@@ -1,0 +1,12 @@
+package com.dac.BackEnd.model.response;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SummaryResponse {
+    private Long totalBlog;
+    private Long totalFilm;
+    private Long totalReviewer;
+}

--- a/BackEnd/src/main/java/com/dac/BackEnd/repository/UserRepository.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/repository/UserRepository.java
@@ -19,4 +19,6 @@ public interface UserRepository extends JpaRepository<UserEntity, Long>{
     // List<UserEntity> findByRoleAndDeletedIsFalse(UserRole role);
     List<UserEntity> findAllByDeleteFlagFalse();
     // Optional<UserEntity> findUserByDeletedFalseAndId(Long id);
+
+    long countByRole(UserRole role);
 }

--- a/BackEnd/src/main/java/com/dac/BackEnd/service/DrashboardService.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/service/DrashboardService.java
@@ -1,0 +1,9 @@
+package com.dac.BackEnd.service;
+
+import com.dac.BackEnd.model.response.SummaryResponse;
+
+public interface DrashboardService {
+
+    SummaryResponse getInfoSummary();
+    
+}

--- a/BackEnd/src/main/java/com/dac/BackEnd/service/impl/DrashboardServiceImpl.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/service/impl/DrashboardServiceImpl.java
@@ -1,0 +1,35 @@
+package com.dac.BackEnd.service.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.dac.BackEnd.entity.UserEntity.UserRole;
+import com.dac.BackEnd.model.response.SummaryResponse;
+import com.dac.BackEnd.repository.BlogRepository;
+import com.dac.BackEnd.repository.FilmRepository;
+import com.dac.BackEnd.repository.UserRepository;
+import com.dac.BackEnd.service.DrashboardService;
+
+@Service
+public class DrashboardServiceImpl implements DrashboardService{
+    
+    @Autowired
+    private BlogRepository blogRepository;
+
+    @Autowired
+    private FilmRepository filmRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Override
+    public SummaryResponse getInfoSummary() {
+        SummaryResponse response = new SummaryResponse();
+        response.setTotalBlog(Long.valueOf(blogRepository.countAllBlogs()));
+        response.setTotalFilm(Long.valueOf(filmRepository.countAllFilm()));
+        response.setTotalReviewer(Long.valueOf(userRepository.countByRole(UserRole.ROLE_REVIEWER)));
+        return response;
+
+
+    }
+}


### PR DESCRIPTION
Added the getInfoSummary method to the appropriate service class to retrieve summary information for the dashboard. This method retrieves the total number of blogs from the database and sets it in the SummaryResponse object. The API endpoint is now ready to provide summary data for the admin dashboard.