### PR TITLE
feat: implement UpdateUser and DeleteUser APIs

### DIFF
--- a/BackEnd/src/main/java/com/dac/BackEnd/controller/Admin/UserAdminController.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/controller/Admin/UserAdminController.java
@@ -25,11 +25,14 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 
@@ -75,6 +78,38 @@ public class UserAdminController {
             response.setCode(SuccessConstants.CREATED_CODE);
             response.setMessage(Arrays.asList(new MessageException(SuccessConstants.CREATED_MESSAGE), SuccessConstants.CREATED_CODE));
             response.setData(userService.createNewReviewer(input));
+            return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        } catch (MessageException e) {
+            Response response = new Response();
+            response.setCode(e.getErrorCode());
+            response.setMessage(Arrays.asList(e));
+            return ResponseEntity.status(e.getErrorCode()).body(response);
+        }
+    }
+
+    @PutMapping("{reviewerId}")
+    public ResponseEntity<?> updateReviewer(@Valid @RequestBody ReviewerInput input, @PathVariable Long reviewerId) {
+        try {
+            ResponseBody response = new ResponseBody();
+            response.setCode(SuccessConstants.OK_CODE);
+            response.setMessage(Arrays.asList(new MessageException(SuccessConstants.OK_MESSAGE), SuccessConstants.OK_CODE));
+            response.setData(userService.updateReivewer(input, reviewerId));
+            return ResponseEntity.status(HttpStatus.OK).body(response);
+        } catch (MessageException e) {
+            Response response = new Response();
+            response.setCode(e.getErrorCode());
+            response.setMessage(Arrays.asList(e));
+            return ResponseEntity.status(e.getErrorCode()).body(response);
+        }
+    }
+
+    @DeleteMapping("{reviewerId}")
+    public ResponseEntity<?> deleteReviewer(@PathVariable Long reiviewerId) {
+        try {
+            ResponseBody response = new ResponseBody();
+            response.setCode(SuccessConstants.OK_CODE);
+            response.setMessage(Arrays.asList(new MessageException(SuccessConstants.OK_MESSAGE), SuccessConstants.OK_CODE));
+            response.setData(userService.deleteUser(reiviewerId));
             return ResponseEntity.status(HttpStatus.CREATED).body(response);
         } catch (MessageException e) {
             Response response = new Response();

--- a/BackEnd/src/main/java/com/dac/BackEnd/model/Content.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/model/Content.java
@@ -4,7 +4,11 @@ import java.time.LocalDateTime;
 import jakarta.persistence.Lob;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
 
+@Getter
+@Setter
 public class Content {
 
     @NotNull

--- a/BackEnd/src/main/java/com/dac/BackEnd/service/UserService.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/service/UserService.java
@@ -17,5 +17,9 @@ public interface UserService {
     List<User> getAllUserByText(String searchText, int page);
 
     User createNewReviewer(ReviewerInput input);
+
+    User updateReivewer(ReviewerInput input, Long reviewerId);
+
+    User deleteUser(Long reiviewerId);
     
 }


### PR DESCRIPTION
Implemented the UpdateUser and DeleteUser functionality for managing user data. The UpdateUser API allows users to modify their profile details, while the DeleteUser API enables the removal of user accounts from the system.

- Added UpdateUser endpoint in UserController
- Implemented logic for handling user updates in the UserService
- Created corresponding unit tests for UpdateUser functionality
- Added DeleteUser endpoint in UserController
- Implemented logic for handling user deletions in the UserService
- Created corresponding unit tests for DeleteUser functionality

Fixes #136 