### PR TITLE
feat: implement film-related APIs

### DIFF
--- a/BackEnd/src/main/java/com/dac/BackEnd/controller/Admin/FilmsAdminController.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/controller/Admin/FilmsAdminController.java
@@ -2,22 +2,42 @@ package com.dac.BackEnd.controller.Admin;
 
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
+import com.dac.BackEnd.constant.ErrorConstants;
 import com.dac.BackEnd.constant.SuccessConstants;
 import com.dac.BackEnd.convertor.FilmConvertor;
 import com.dac.BackEnd.exception.MessageException;
+import com.dac.BackEnd.model.request.FilmInput;
 import com.dac.BackEnd.model.response.Response;
+import com.dac.BackEnd.model.response.ResponseBody;
 import com.dac.BackEnd.model.response.ResponsesBody;
 import com.dac.BackEnd.service.FilmService;
 
+import jakarta.validation.Valid;
+
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
 
 
 @RestController
@@ -60,5 +80,86 @@ public class FilmsAdminController {
         }
         
     }
+
+    @PostMapping()
+    public ResponseEntity<?> createNewFilm(@Valid FilmInput filmInput,
+                                            @RequestPart(value = "file") MultipartFile file) {
+        try {
+            ResponseBody response = new ResponseBody();
+            response.setCode(SuccessConstants.CREATED_CODE);
+            response.setMessage(Arrays.asList(new MessageException(SuccessConstants.CREATED_MESSAGE), SuccessConstants.CREATED_CODE));
+            response.setData(filmService.createNewFilm(filmInput, file));
+            return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        } catch (MessageException e) {
+            Response response = new Response();
+            response.setCode(e.getErrorCode());
+            response.setMessage(Arrays.asList(e));
+            return ResponseEntity.status(e.getErrorCode()).body(response);
+        }
+    }
+
+    @PutMapping("{filmId}")
+    public ResponseEntity<?> updateFilm(@RequestBody FilmInput input, @PathVariable Long filmId) {
+        try {
+            ResponseBody response = new ResponseBody();
+            response.setCode(SuccessConstants.OK_CODE);
+            response.setMessage(Arrays.asList(new MessageException(SuccessConstants.OK_MESSAGE), SuccessConstants.OK_CODE));
+            response.setData(filmService.updateFilm(input, filmId));
+            return ResponseEntity.status(HttpStatus.OK).body(response);
+        } catch (MessageException e) {
+            Response response = new Response();
+            response.setCode(e.getErrorCode());
+            response.setMessage(Arrays.asList(e));
+            return ResponseEntity.status(e.getErrorCode()).body(response);
+        }
+    }
+
+    @PatchMapping("{filmId}")
+    public ResponseEntity<?> updateImageFilm(@RequestPart(value = "file") MultipartFile file, @PathVariable Long filmId) {
+        try {
+            ResponseBody response = new ResponseBody();
+            response.setCode(SuccessConstants.OK_CODE);
+            response.setMessage(Arrays.asList(new MessageException(SuccessConstants.OK_MESSAGE), SuccessConstants.OK_CODE));
+            response.setData(filmService.updateImageFilm(file, filmId));
+            return ResponseEntity.status(HttpStatus.OK).body(response);
+        } catch (MessageException e) {
+            Response response = new Response();
+            response.setCode(e.getErrorCode());
+            response.setMessage(Arrays.asList(e));
+            return ResponseEntity.status(e.getErrorCode()).body(response);
+        }
+    }
+
+    @DeleteMapping("{filmId}")
+    public ResponseEntity<Response> deleteFilm(@PathVariable Long filmId) {
+        try {
+            Response response = new Response();
+            response.setCode(SuccessConstants.OK_CODE);
+            response.setMessage(Arrays.asList(new MessageException(SuccessConstants.OK_MESSAGE), SuccessConstants.OK_CODE));
+            filmService.deleteFilm(filmId);
+            return ResponseEntity.status(HttpStatus.OK).body(response);
+        } catch (MessageException e) {
+            Response response = new Response();
+            response.setCode(e.getErrorCode());
+            response.setMessage(Arrays.asList(e));
+            return ResponseEntity.status(e.getErrorCode()).body(response);
+        }
+        
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public Response handleValidationExceptions(MethodArgumentNotValidException ex){
+        Response response = new Response();
+        response.setCode(ErrorConstants.INVALID_DATA_CODE);
+        List<Object> messages = new ArrayList<>();
+        ex.getBindingResult().getAllErrors().forEach((error)->{
+            String fieldName = ((FieldError) error).getField();
+            messages.add(new MessageException(fieldName + ": " + error.getDefaultMessage(), response.getCode()));
+        });
+        response.setMessage(messages);
+        return response;
+    }
+    
     
 }

--- a/BackEnd/src/main/java/com/dac/BackEnd/controller/Admin/UserAdminController.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/controller/Admin/UserAdminController.java
@@ -106,11 +106,11 @@ public class UserAdminController {
     @DeleteMapping("{reviewerId}")
     public ResponseEntity<?> deleteReviewer(@PathVariable Long reiviewerId) {
         try {
-            ResponseBody response = new ResponseBody();
+            Response response = new Response();
             response.setCode(SuccessConstants.OK_CODE);
             response.setMessage(Arrays.asList(new MessageException(SuccessConstants.OK_MESSAGE), SuccessConstants.OK_CODE));
-            response.setData(userService.deleteUser(reiviewerId));
-            return ResponseEntity.status(HttpStatus.CREATED).body(response);
+            userService.deleteUser(reiviewerId);
+            return ResponseEntity.status(HttpStatus.OK).body(response);
         } catch (MessageException e) {
             Response response = new Response();
             response.setCode(e.getErrorCode());

--- a/BackEnd/src/main/java/com/dac/BackEnd/convertor/FilmConvertor.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/convertor/FilmConvertor.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.dac.BackEnd.entity.FilmEntity;
-import com.dac.BackEnd.model.Blog;
 import com.dac.BackEnd.model.Film;
 
 public class FilmConvertor {
@@ -14,6 +13,7 @@ public class FilmConvertor {
         film.setId(entity.getId());
         film.setCategory(CategoryConvertor.toModel(entity.getCategory()));
         film.setNameFilm(entity.getNameFilm());
+        film.setImage(entity.getImage());
         film.setDirector(entity.getDirector());
         film.setCountry(entity.getCountry());
         film.setStartDate(entity.getStartDate());

--- a/BackEnd/src/main/java/com/dac/BackEnd/entity/FilmEntity.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/entity/FilmEntity.java
@@ -41,6 +41,8 @@ public class FilmEntity {
     @Size(max = 255)
     private String nameFilm;
 
+    private String image;
+
     @NotBlank
     @Size(max = 255)
     private String director;

--- a/BackEnd/src/main/java/com/dac/BackEnd/model/Film.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/model/Film.java
@@ -25,6 +25,8 @@ public class Film {
     @Size(max = 255)
     private String nameFilm;
 
+    private String image;
+
     @NotBlank
     @Size(max = 255)
     private String director;

--- a/BackEnd/src/main/java/com/dac/BackEnd/model/request/FilmInput.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/model/request/FilmInput.java
@@ -1,0 +1,35 @@
+package com.dac.BackEnd.model.request;
+
+import java.time.LocalDate;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class FilmInput {
+    private Long categoryId;
+
+    @NotBlank
+    @Size(max = 50)
+    private String nameFilm;
+
+    @NotBlank
+    @Size(max = 30)
+    private String director;
+
+    @NotBlank
+    @Size(max = 5)
+    private String country;
+
+    @NotNull
+    private LocalDate startDate;
+
+    @NotBlank
+    @Size(max = 255)
+    private String description;
+
+}

--- a/BackEnd/src/main/java/com/dac/BackEnd/repository/UserRepository.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/repository/UserRepository.java
@@ -35,4 +35,6 @@ public interface UserRepository extends JpaRepository<UserEntity, Long>{
     Page<UserEntity> findByTextInName(String searchText, Pageable pageable);
 
     List<UserEntity> findAllByStatus(UserStatus status, Pageable pageable);
+
+    Optional<UserEntity> findByEmailAndRole(String email, UserRole role);
 }

--- a/BackEnd/src/main/java/com/dac/BackEnd/service/FilmService.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/service/FilmService.java
@@ -3,8 +3,13 @@ package com.dac.BackEnd.service;
 import java.time.LocalDate;
 import java.util.List;
 
+import org.springframework.web.multipart.MultipartFile;
+
 import com.dac.BackEnd.model.Film;
+import com.dac.BackEnd.model.request.FilmInput;
+import com.dac.BackEnd.model.request.ReviewerInput;
 import com.dac.BackEnd.model.response.ResponsePage;
+
 
 
 public interface FilmService {
@@ -20,5 +25,13 @@ public interface FilmService {
     List<Film> getAllFilmByStartDate(LocalDate startTime, LocalDate endTime, int page);
 
     List<Film> getAllFilmDeleteFalse();
+
+    Film createNewFilm(FilmInput filmInput, MultipartFile file);
+
+    Film updateFilm(FilmInput input, Long filmId);
+
+    Film updateImageFilm(MultipartFile file, Long filmId);
+
+    void deleteFilm(Long filmId);
     
 }

--- a/BackEnd/src/main/java/com/dac/BackEnd/service/UserService.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/service/UserService.java
@@ -20,6 +20,6 @@ public interface UserService {
 
     User updateReivewer(ReviewerInput input, Long reviewerId);
 
-    User deleteUser(Long reiviewerId);
+    void deleteUser(Long reiviewerId);
     
 }

--- a/BackEnd/src/main/java/com/dac/BackEnd/service/impl/ImageServiceImpl.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/service/impl/ImageServiceImpl.java
@@ -43,7 +43,6 @@ public class ImageServiceImpl implements ImageService{
             if (file.isEmpty()) {
                 throw new IOException("Cannot upload empty file");
             }
-            File file1 = convertMultiPartToFile(file);
             switch (type) {
                 case "BlogImage":
                     imageFor = "BlogImage";
@@ -67,14 +66,6 @@ public class ImageServiceImpl implements ImageService{
          } catch (Exception e) {
             throw new MessageException(ErrorConstants.NOT_FOUND_MESSAGE, ErrorConstants.NOT_FOUND_CODE);
          }
-    }
-
-    private File convertMultiPartToFile(MultipartFile file) throws IOException {
-        File convFile = new File(file.getOriginalFilename());
-        FileOutputStream fos = new FileOutputStream(convFile);
-        fos.write(file.getBytes());
-        fos.close();
-        return convFile;
     }
 
     private String generateFileName(MultipartFile multiPart) {

--- a/BackEnd/src/main/java/com/dac/BackEnd/service/impl/UserServiceImpl.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/service/impl/UserServiceImpl.java
@@ -158,14 +158,14 @@ public class UserServiceImpl implements UserService{
 
 
     @Override
-    public User deleteUser(Long reviewerId) {
+    public void deleteUser(Long reviewerId) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication == null) {
             throw new MessageException(ErrorConstants.UNAUTHORIZED_MESSAGE, ErrorConstants.UNAUTHORIZED_CODE);
         }
         UserEntity entity = userRepository.findById(reviewerId).orElseThrow(() ->  new MessageException(ErrorConstants.NOT_FOUND_MESSAGE, ErrorConstants.NOT_FOUND_CODE));
         entity.setDeleteFlag(true);
-        return UserConvertor.toModel(userRepository.save(entity));
+        userRepository.save(entity);
 
     }
 }


### PR DESCRIPTION
- createFilm API: Add endpoint for creating a new film with necessary validation checks.
- updateFilm API: Implement logic to update film details based on provided data.
- updateImageFilm API: Allow users to update the image associated with a film.
- deleteFilm API: Add endpoint to delete a film based on its identifier.

Fixes #69