### PR TITLE
fix: add image upload to S3 in createNewBlog API

### DIFF
--- a/BackEnd/src/main/java/com/dac/BackEnd/constant/TypeImageConstants.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/constant/TypeImageConstants.java
@@ -1,0 +1,7 @@
+package com.dac.BackEnd.constant;
+
+public class TypeImageConstants {
+    public static final String BLOG_IMAGE = "BlogImage";
+    public static final String FILM_IMAGE = "FilmImage";
+    public static final String CONTENT_IMAGE = "ContentImage";
+}

--- a/BackEnd/src/main/java/com/dac/BackEnd/controller/Admin/BlogsAdminController.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/controller/Admin/BlogsAdminController.java
@@ -7,25 +7,32 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Arrays;
+import java.util.List;
 import java.time.LocalDateTime;
 
 import com.dac.BackEnd.constant.SuccessConstants;
 import com.dac.BackEnd.convertor.BlogConvertor;
 import com.dac.BackEnd.exception.MessageException;
 import com.dac.BackEnd.model.Blog;
+import com.dac.BackEnd.model.request.BlogInput;
 import com.dac.BackEnd.model.request.BlogStatusRequest;
+import com.dac.BackEnd.model.request.ContentInput;
 import com.dac.BackEnd.model.response.Response;
 import com.dac.BackEnd.model.response.ResponseBody;
 import com.dac.BackEnd.model.response.ResponsesBody;
 import com.dac.BackEnd.service.BlogService;
 
 import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
 
 
 
@@ -88,6 +95,70 @@ public class BlogsAdminController {
             body.setCode(e.getErrorCode());
             body.setMessage(Arrays.asList(e));
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
+        }
+    }
+
+    @PutMapping("{blogId}")
+    public ResponseEntity<?> updateBlog(@Valid @RequestBody BlogInput blogInput, @PathVariable Long blogId) {
+        try {
+            ResponseBody response = new ResponseBody();
+            response.setCode(SuccessConstants.OK_CODE);
+            response.setMessage(Arrays.asList(new MessageException(SuccessConstants.OK_MESSAGE), SuccessConstants.OK_CODE));
+            response.setData(blogService.updateBlog(blogInput, blogId));
+            return ResponseEntity.status(HttpStatus.OK).body(response);
+        } catch (MessageException e) {
+            Response response = new Response();
+            response.setCode(e.getErrorCode());
+            response.setMessage(Arrays.asList(e));
+            return ResponseEntity.status(e.getErrorCode()).body(response);
+        }
+    }
+
+    @PatchMapping("{blogId}/image")
+    public ResponseEntity<?> updateImageBlog(@RequestPart(value = "file") MultipartFile file, @PathVariable Long blogId) {
+        try {
+            ResponseBody response = new ResponseBody();
+            response.setCode(SuccessConstants.OK_CODE);
+            response.setMessage(Arrays.asList(new MessageException(SuccessConstants.OK_MESSAGE), SuccessConstants.OK_CODE));
+            response.setData(blogService.updateImageBlog(file, blogId));
+            return ResponseEntity.status(HttpStatus.OK).body(response);
+        } catch (MessageException e) {
+            Response response = new Response();
+            response.setCode(e.getErrorCode());
+            response.setMessage(Arrays.asList(e));
+            return ResponseEntity.status(e.getErrorCode()).body(response);
+        }
+    }
+
+    @PutMapping("{blogId}/content")
+    public ResponseEntity<?> updateConent(@Valid @RequestBody List<ContentInput> contentInputs, @PathVariable Long blogId) {
+        try {
+            ResponseBody response = new ResponseBody();
+            response.setCode(SuccessConstants.OK_CODE);
+            response.setMessage(Arrays.asList(new MessageException(SuccessConstants.OK_MESSAGE), SuccessConstants.OK_CODE));
+            response.setData(blogService.updateContent(contentInputs, blogId));
+            return ResponseEntity.status(HttpStatus.OK).body(response);
+        } catch (MessageException e) {
+            Response response = new Response();
+            response.setCode(e.getErrorCode());
+            response.setMessage(Arrays.asList(e));
+            return ResponseEntity.status(e.getErrorCode()).body(response);
+        }
+    }
+
+    @PatchMapping("{blogId}/content/image")
+    public ResponseEntity<?> updateImageContent(@RequestPart(value = "files") List<ContentInput> contents, @PathVariable Long blogId) {
+        try {
+            ResponseBody response = new ResponseBody();
+            response.setCode(SuccessConstants.OK_CODE);
+            response.setMessage(Arrays.asList(new MessageException(SuccessConstants.OK_MESSAGE), SuccessConstants.OK_CODE));
+            response.setData(blogService.updateImageContent(contents, blogId));
+            return ResponseEntity.status(HttpStatus.OK).body(response);
+        } catch (MessageException e) {
+            Response response = new Response();
+            response.setCode(e.getErrorCode());
+            response.setMessage(Arrays.asList(e));
+            return ResponseEntity.status(e.getErrorCode()).body(response);
         }
     }
 

--- a/BackEnd/src/main/java/com/dac/BackEnd/controller/Admin/FilmsAdminController.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/controller/Admin/FilmsAdminController.java
@@ -41,7 +41,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 
 @RestController
-@RequestMapping("api/admin/film")
+@RequestMapping("api/admin/films")
 public class FilmsAdminController {
 
     @Autowired
@@ -82,13 +82,12 @@ public class FilmsAdminController {
     }
 
     @PostMapping()
-    public ResponseEntity<?> createNewFilm(@Valid FilmInput filmInput,
-                                            @RequestPart(value = "file") MultipartFile file) {
+    public ResponseEntity<?> createNewFilm(@Valid FilmInput filmInput) {
         try {
             ResponseBody response = new ResponseBody();
             response.setCode(SuccessConstants.CREATED_CODE);
             response.setMessage(Arrays.asList(new MessageException(SuccessConstants.CREATED_MESSAGE), SuccessConstants.CREATED_CODE));
-            response.setData(filmService.createNewFilm(filmInput, file));
+            response.setData(filmService.createNewFilm(filmInput));
             return ResponseEntity.status(HttpStatus.CREATED).body(response);
         } catch (MessageException e) {
             Response response = new Response();

--- a/BackEnd/src/main/java/com/dac/BackEnd/controller/AuthController.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/controller/AuthController.java
@@ -2,9 +2,7 @@ package com.dac.BackEnd.controller;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;

--- a/BackEnd/src/main/java/com/dac/BackEnd/controller/CategoryController.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/controller/CategoryController.java
@@ -1,7 +1,6 @@
 package com.dac.BackEnd.controller;
 
 import java.util.Arrays;
-import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -10,12 +9,10 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.dac.BackEnd.constant.SuccessConstants;
 import com.dac.BackEnd.exception.MessageException;
-import com.dac.BackEnd.model.Category;
 import com.dac.BackEnd.model.response.Response;
 import com.dac.BackEnd.model.response.ResponseBody;
 import com.dac.BackEnd.service.CategoryService;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 
 
 @RestController

--- a/BackEnd/src/main/java/com/dac/BackEnd/controller/Reviewer/BlogReviewerController.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/controller/Reviewer/BlogReviewerController.java
@@ -7,14 +7,10 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 
 import com.dac.BackEnd.constant.ErrorConstants;
 import com.dac.BackEnd.constant.SuccessConstants;
@@ -27,10 +23,8 @@ import com.dac.BackEnd.service.BlogService;
 import jakarta.validation.Valid;
 
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.GetMapping;
 
 
 
@@ -42,13 +36,12 @@ public class BlogReviewerController {
     private BlogService blogService;
 
     @PostMapping()
-    public ResponseEntity<?> createNewBlog(@Valid BlogInput blogInput, 
-                                            @RequestPart(value = "file") MultipartFile file) {
+    public ResponseEntity<?> createNewBlog(@Valid BlogInput blogInput){
         try {
             ResponseBody response = new ResponseBody();
             response.setCode(SuccessConstants.CREATED_CODE);
             response.setMessage(Arrays.asList(new MessageException(SuccessConstants.CREATED_MESSAGE), SuccessConstants.CREATED_CODE));
-            response.setData(blogService.createNewBlog(blogInput, file));
+            response.setData(blogService.createNewBlog(blogInput));
             return ResponseEntity.status(HttpStatus.CREATED).body(response);
         } catch (MessageException e) {
             Response response = new Response();

--- a/BackEnd/src/main/java/com/dac/BackEnd/convertor/BlogConvertor.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/convertor/BlogConvertor.java
@@ -3,7 +3,6 @@ package com.dac.BackEnd.convertor;
 import java.util.List;
 import java.util.ArrayList;
 
-import com.dac.BackEnd.entity.ContentEntity;
 import com.dac.BackEnd.entity.BlogEntity.BlogEntity;
 import com.dac.BackEnd.model.Blog;
 

--- a/BackEnd/src/main/java/com/dac/BackEnd/convertor/ContentConvertor.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/convertor/ContentConvertor.java
@@ -6,8 +6,13 @@ import com.dac.BackEnd.model.Content;
 public class ContentConvertor {
     public static Content toModel(ContentEntity entity) {
         Content content = new Content();
-
-
+        content.setId(entity.getId());
+        content.setImageUrl(entity.getImageUrl());
+        content.setContent(entity.getContent());
+        content.setInsertBy(UserConvertor.toModel(entity.getInsertBy()));
+        content.setInsertDateTime(entity.getInsertDateTime());
+        content.setUpdateBy(UserConvertor.toModel(entity.getUpdateBy()));
+        content.setUpdateDateTime(entity.getUpdateDateTime());
         return content;
     }
 }

--- a/BackEnd/src/main/java/com/dac/BackEnd/entity/ContentEntity.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/entity/ContentEntity.java
@@ -16,7 +16,6 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/BackEnd/src/main/java/com/dac/BackEnd/exception/MessageException.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/exception/MessageException.java
@@ -1,8 +1,5 @@
 package com.dac.BackEnd.exception;
 
-import java.util.Arrays;
-import java.util.List;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import lombok.Getter;

--- a/BackEnd/src/main/java/com/dac/BackEnd/model/Film.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/model/Film.java
@@ -3,8 +3,6 @@ package com.dac.BackEnd.model;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
-import com.dac.BackEnd.entity.UserEntity.UserEntity;
-
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;

--- a/BackEnd/src/main/java/com/dac/BackEnd/model/request/BlogInput.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/model/request/BlogInput.java
@@ -21,6 +21,8 @@ public class BlogInput {
     @Size(max = 255)
     private String title;
 
+    private MultipartFile blogImage;
+
     @NotBlank
     @Size(max = 700)
     private String summary;

--- a/BackEnd/src/main/java/com/dac/BackEnd/model/request/ContentInput.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/model/request/ContentInput.java
@@ -1,5 +1,7 @@
 package com.dac.BackEnd.model.request;
 
+import org.springframework.web.multipart.MultipartFile;
+
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
@@ -9,7 +11,9 @@ import lombok.Setter;
 @Setter
 public class ContentInput {
 
-    private String imageUrl;
+    private Long id;
+
+    private MultipartFile image;
 
     @NotBlank
     @Size(min = 1)

--- a/BackEnd/src/main/java/com/dac/BackEnd/model/request/FilmInput.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/model/request/FilmInput.java
@@ -2,6 +2,8 @@ package com.dac.BackEnd.model.request;
 
 import java.time.LocalDate;
 
+import org.springframework.web.multipart.MultipartFile;
+
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -16,6 +18,8 @@ public class FilmInput {
     @NotBlank
     @Size(max = 50)
     private String nameFilm;
+
+    private MultipartFile filmImage;
 
     @NotBlank
     @Size(max = 30)

--- a/BackEnd/src/main/java/com/dac/BackEnd/model/request/LoginInput.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/model/request/LoginInput.java
@@ -2,7 +2,6 @@ package com.dac.BackEnd.model.request;
 
 import org.hibernate.annotations.NaturalId;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;

--- a/BackEnd/src/main/java/com/dac/BackEnd/repository/FilmRepository.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/repository/FilmRepository.java
@@ -27,6 +27,8 @@ public interface FilmRepository extends JpaRepository<FilmEntity, Long>{
     @Query("SELECT COUNT(f) FROM FilmEntity f WHERE (f.startDate BETWEEN :startTime AND :endTime) AND f.deleteFlag = false")
     int countAllBlogsByStartDate(LocalDate startTime, LocalDate endTime);
 
+    List<FilmEntity> findByDeleteFlagFalse(Pageable pageable);
+
     List<FilmEntity> findByCategoryAndDeleteFlagFalse(CategoryEntity category, Pageable pageable);
 
     @Query("SELECT f FROM FilmEntity f WHERE (f.nameFilm LIKE %:searchText% OR f.description LIKE %:searchText%) AND f.deleteFlag = false")

--- a/BackEnd/src/main/java/com/dac/BackEnd/repository/UserRepository.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/repository/UserRepository.java
@@ -22,24 +22,24 @@ public interface UserRepository extends JpaRepository<UserEntity, Long>{
 
     Boolean existsByEmail(String email);
 
-    @Query("SELECT COUNT(u) FROM UserEntity u WHERE u.role = UserRole.ROLE_REVIEWER")
+    @Query("SELECT COUNT(u) FROM UserEntity u WHERE u.role = UserRole.ROLE_REVIEWER AND u.deleteFlag = false")
     long countAllReviewer();
 
-    @Query("SELECT COUNT(u) FROM UserEntity u WHERE u.role = UserRole.ROLE_REVIEWER AND u.status = :status")
+    @Query("SELECT COUNT(u) FROM UserEntity u WHERE u.role = UserRole.ROLE_REVIEWER AND u.status = :status AND u.deleteFlag = false")
     long countReviewerByStatus(@Param("status") UserStatus status);
 
-    @Query("SELECT COUNT(u) FROM UserEntity u WHERE u.role = UserRole.ROLE_REVIEWER AND u.name LIKE %:searchText% ")
+    @Query("SELECT COUNT(u) FROM UserEntity u WHERE u.role = UserRole.ROLE_REVIEWER AND u.name LIKE %:searchText%  AND u.deleteFlag = false")
     int countReviewerByTextInName(@Param("searchText") String searchText);
 
     long countByRole(UserRole role);
 
-    @Query("SELECT u FROM UserEntity u WHERE u.role = UserRole.ROLE_REVIEWER")
+    @Query("SELECT u FROM UserEntity u WHERE u.role = UserRole.ROLE_REVIEWER AND u.deleteFlag = false")
     List<UserEntity> findAllReviewer(Pageable pageable);
 
-    @Query("SELECT u FROM UserEntity u WHERE u.role = UserRole.ROLE_REVIEWER AND u.status = :status")
+    @Query("SELECT u FROM UserEntity u WHERE u.role = UserRole.ROLE_REVIEWER AND u.status = :status AND u.deleteFlag = false")
     List<UserEntity> findAllReviewersByStatus(@Param("status") UserStatus status, Pageable pageable);
 
-    @Query("SELECT u FROM UserEntity u WHERE u.role = UserRole.ROLE_REVIEWER AND LOWER(u.name) LIKE %:searchText%")
+    @Query("SELECT u FROM UserEntity u WHERE u.role = UserRole.ROLE_REVIEWER AND LOWER(u.name) LIKE %:searchText% AND u.deleteFlag = false")
     Page<UserEntity> findReviewerByTextInName(String searchText, Pageable pageable);
 
     Optional<UserEntity> findByEmailAndRole(String email, UserRole role);

--- a/BackEnd/src/main/java/com/dac/BackEnd/security/userprincal/CustomAuthenticationProvider.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/security/userprincal/CustomAuthenticationProvider.java
@@ -1,7 +1,6 @@
 package com.dac.BackEnd.security.userprincal;
 
 import org.springframework.security.authentication.AuthenticationProvider;
-import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;

--- a/BackEnd/src/main/java/com/dac/BackEnd/service/BlogService.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/service/BlogService.java
@@ -5,9 +5,10 @@ import java.util.List;
 
 import org.springframework.web.multipart.MultipartFile;
 
-import com.dac.BackEnd.entity.BlogEntity.BlogEntity;
 import com.dac.BackEnd.model.Blog;
+import com.dac.BackEnd.model.Content;
 import com.dac.BackEnd.model.request.BlogInput;
+import com.dac.BackEnd.model.request.ContentInput;
 import com.dac.BackEnd.model.response.ResponsePage;
 
 public interface BlogService {
@@ -26,9 +27,17 @@ public interface BlogService {
 
     List<Blog> getAllBlogByPostTime(LocalDateTime startTime, LocalDateTime endTime, int page);
 
-    Blog createNewBlog(BlogInput blogInput,  MultipartFile file);
+    Blog createNewBlog(BlogInput blogInput);
 
     void deleteBlog(Long blogId);
+
+    Blog updateBlog(BlogInput blogInput, Long blogId);
+
+    List<Content> updateContent(List<ContentInput> contentInputs, Long blogId);
+
+    Object updateImageBlog(MultipartFile file, Long blogId);
+
+    Object updateImageContent(List<ContentInput> contents, Long blogId);
 
     
 

--- a/BackEnd/src/main/java/com/dac/BackEnd/service/FilmService.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/service/FilmService.java
@@ -7,7 +7,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.dac.BackEnd.model.Film;
 import com.dac.BackEnd.model.request.FilmInput;
-import com.dac.BackEnd.model.request.ReviewerInput;
 import com.dac.BackEnd.model.response.ResponsePage;
 
 
@@ -26,7 +25,7 @@ public interface FilmService {
 
     List<Film> getAllFilmDeleteFalse();
 
-    Film createNewFilm(FilmInput filmInput, MultipartFile file);
+    Film createNewFilm(FilmInput filmInput);
 
     Film updateFilm(FilmInput input, Long filmId);
 

--- a/BackEnd/src/main/java/com/dac/BackEnd/service/ImageService.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/service/ImageService.java
@@ -1,7 +1,5 @@
 package com.dac.BackEnd.service;
 
-import java.io.IOException;
-
 import org.springframework.web.multipart.MultipartFile;
 
 public interface ImageService {

--- a/BackEnd/src/main/java/com/dac/BackEnd/service/impl/DashboardServiceImpl.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/service/impl/DashboardServiceImpl.java
@@ -3,7 +3,6 @@ package com.dac.BackEnd.service.impl;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import com.dac.BackEnd.entity.UserEntity.UserRole;
 import com.dac.BackEnd.model.response.SummaryResponse;
 import com.dac.BackEnd.repository.BlogRepository;
 import com.dac.BackEnd.repository.FilmRepository;

--- a/BackEnd/src/main/java/com/dac/BackEnd/service/impl/ImageServiceImpl.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/service/impl/ImageServiceImpl.java
@@ -1,25 +1,20 @@
 package com.dac.BackEnd.service.impl;
 
-import java.io.File;
-import java.io.FileOutputStream;
+
 import java.io.IOException;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.amazonaws.services.s3.model.CannedAccessControlList;
-import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectResult;
 import com.dac.BackEnd.constant.ErrorConstants;
+import com.dac.BackEnd.constant.TypeImageConstants;
 import com.dac.BackEnd.exception.MessageException;
 import com.dac.BackEnd.service.AmazonS3Service;
 import com.dac.BackEnd.service.ImageService;
@@ -44,11 +39,14 @@ public class ImageServiceImpl implements ImageService{
                 throw new IOException("Cannot upload empty file");
             }
             switch (type) {
-                case "BlogImage":
-                    imageFor = "BlogImage";
+                case TypeImageConstants.BLOG_IMAGE:
+                    imageFor = TypeImageConstants.BLOG_IMAGE;
                     break;
-                case "FilmImage":
-                    imageFor = "FilmImage";
+                case TypeImageConstants.FILM_IMAGE:
+                    imageFor = TypeImageConstants.FILM_IMAGE;
+                    break;
+                case TypeImageConstants.CONTENT_IMAGE:
+                    imageFor = TypeImageConstants.CONTENT_IMAGE;
                     break;
                 default:
                     throw new MessageException(ErrorConstants.NOT_FOUND_MESSAGE, ErrorConstants.NOT_FOUND_CODE);

--- a/BackEnd/src/main/java/com/dac/BackEnd/service/impl/UserServiceImpl.java
+++ b/BackEnd/src/main/java/com/dac/BackEnd/service/impl/UserServiceImpl.java
@@ -1,13 +1,10 @@
 package com.dac.BackEnd.service.impl;
 
 import java.time.LocalDateTime;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.springframework.beans.BeanUtils;
-import org.springframework.beans.BeanWrapper;
-import org.springframework.beans.BeanWrapperImpl;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.security.core.Authentication;


### PR DESCRIPTION
Add functionality to upload images to Amazon S3 when creating a new blog. This enhances the createNewBlog API by allowing users to include images associated with their blogs.

Introduce new APIs, updateImageBlog and updateContent, to handle the update of blog images and content. These APIs provide the ability to modify existing blogs by updating their images or content, enhancing the overall flexibility of the application.

Fixes #141